### PR TITLE
Here's a summary of the changes made in this commit:

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -83,5 +83,5 @@ export const VSCODE_OPENAI_SERVICE_PROVIDER = {
   OPENAI: '$(vscode-openai)  openai.com',
   AZURE_OPENAI: '$(azure)  openai.azure.com',
   CREDAL: '$(comment)  credal.ai',
-  CHANGE_MODEL: '$(symbol-function)  Change Models',
+  CHANGE_MODEL: '$(extensions)  change models',
 }

--- a/src/quickPicks/getAvailableModels.ts
+++ b/src/quickPicks/getAvailableModels.ts
@@ -24,7 +24,9 @@ export async function getAvailableModelsOpenai(
   )
 
   // Map each returned label into a QuickPickItem object with label property set as label value returned by API call.
-  return chatCompletionModels.map((label) => ({ label }))
+  return chatCompletionModels.map((label) => ({
+    label: `$(symbol-function)  ${label}`,
+  }))
 }
 
 /**
@@ -48,7 +50,7 @@ export async function getAvailableModelsAzure(
   const quickPickItems: QuickPickItem[] = []
   chatCompletionModels?.forEach((deployment) => {
     quickPickItems.push({
-      label: deployment.deployment,
+      label: `$(symbol-function)  ${deployment.deployment}`,
       description: deployment.model,
     })
   })

--- a/src/quickPicks/quickPickChangeModel.ts
+++ b/src/quickPicks/quickPickChangeModel.ts
@@ -126,8 +126,15 @@ export async function quickPickChangeModel(
 
   //Start openai.com configuration processes
   const state = await collectInputs()
-  ConfigurationSettingService.instance.defaultModel =
-    state.chatModelQuickPickItem.label
-  ConfigurationSettingService.instance.embeddingModel =
-    state.embeddingModelQuickPickItem.label
+
+  const inferenceModel = state.chatModelQuickPickItem.label.replace(
+    `$(symbol-function)  `,
+    ''
+  )
+  const embeddingModel = state.embeddingModelQuickPickItem.label.replace(
+    `$(symbol-function)  `,
+    ''
+  )
+  ConfigurationSettingService.instance.defaultModel = inferenceModel
+  ConfigurationSettingService.instance.embeddingModel = embeddingModel
 }

--- a/src/quickPicks/quickPickSetupAzureOpenai.ts
+++ b/src/quickPicks/quickPickSetupAzureOpenai.ts
@@ -61,7 +61,7 @@ export async function quickPickSetupAzureOpenai(
       valueSelection:
         typeof state.openaiBaseUrl === 'string' ? undefined : [8, 16],
       prompt:
-        'Enter you instance name. Provide the base url for example "https://instance.openai.azure.com/openai"',
+        '$(globe)  Enter you instance name. Provide the base url for example "https://instance.openai.azure.com/openai"',
       placeholder: 'https://instance.openai.azure.com/openai',
       validate: validateOpenaiBaseUrl,
       shouldResume: shouldResume,
@@ -85,7 +85,7 @@ export async function quickPickSetupAzureOpenai(
       totalSteps: 4,
       ignoreFocusOut: true,
       value: typeof state.openaiApiKey === 'string' ? state.openaiApiKey : '',
-      prompt: 'Enter you openai.com Api-Key',
+      prompt: '$(key)  Enter you openai.com Api-Key',
       placeholder: 'ed4af062d8567543ad104587ea4505ce',
       validate: validateAzureOpenaiApiKey,
       shouldResume: shouldResume,
@@ -193,9 +193,15 @@ export async function quickPickSetupAzureOpenai(
   //Start openai.com configuration processes
   const state = await collectInputs()
   const inferenceModel = state.quickPickInferenceModel.description as string
-  const inferenceDeployment = state.quickPickInferenceModel.label
+  const inferenceDeployment = state.quickPickInferenceModel.label.replace(
+    `$(symbol-function)  `,
+    ''
+  )
   const embeddingModel = state.quickPickEmbeddingModel.description as string
-  const embeddingDeployment = state.quickPickEmbeddingModel.label
+  const embeddingDeployment = state.quickPickEmbeddingModel.label.replace(
+    `$(symbol-function)  `,
+    ''
+  )
 
   await SecretStorageService.instance.setAuthApiKey(state.openaiApiKey)
   await ConfigurationSettingService.loadConfigurationService({

--- a/src/quickPicks/quickPickSetupCredalOpenai.ts
+++ b/src/quickPicks/quickPickSetupCredalOpenai.ts
@@ -51,7 +51,7 @@ export async function quickPickSetupCredalOpenai(
       totalSteps: 2,
       ignoreFocusOut: true,
       value: typeof state.openaiApiKey === 'string' ? state.openaiApiKey : '',
-      prompt: 'Enter you openai.com Api-Key',
+      prompt: '$(key)  Enter you openai.com Api-Key',
       placeholder: 'eyJh...CJ9.eyJ1dW...NDk2fQ.hiBLQ...66W18',
       validate: validateOpenaiApiKey,
       shouldResume: shouldResume,
@@ -77,7 +77,7 @@ export async function quickPickSetupCredalOpenai(
       totalSteps: 2,
       ignoreFocusOut: true,
       placeholder:
-        'Selected Chat Completion DeploymentModel (if empty, no valid chat completion models found)',
+        '$(symbol-function)  Selected Chat Completion DeploymentModel (if empty, no valid chat completion models found)',
       items: models,
       activeItem: state.quickPickInferenceModel,
       shouldResume: shouldResume,

--- a/src/quickPicks/quickPickSetupOpenai.ts
+++ b/src/quickPicks/quickPickSetupOpenai.ts
@@ -61,7 +61,7 @@ export async function quickPickSetupOpenai(
       valueSelection:
         typeof state.openaiBaseUrl === 'string' ? undefined : [0, 25],
       prompt:
-        'Enter you instance name. Provide the base url default https://api.openai.com/v1"',
+        '$(globe)  Enter you instance name. Provide the base url default https://api.openai.com/v1"',
       placeholder: 'https://api.openai.com/v1',
       validate: validateOpenaiBaseUrl,
       shouldResume: shouldResume,
@@ -85,7 +85,7 @@ export async function quickPickSetupOpenai(
       totalSteps: 4,
       ignoreFocusOut: true,
       value: typeof state.openaiApiKey === 'string' ? state.openaiApiKey : '',
-      prompt: 'Enter you openai.com Api-Key',
+      prompt: `$(key)  Enter you openai.com Api-Key`,
       placeholder: 'sk-8i6055nAY3eAwARfHFjiT5BlbkFJAEFUvG5GwtAV2RiwP87h',
       validate: validateOpenaiApiKey,
       shouldResume: shouldResume,
@@ -196,11 +196,20 @@ export async function quickPickSetupOpenai(
   const state = await collectInputs()
 
   await SecretStorageService.instance.setAuthApiKey(state.openaiApiKey)
+  const inferenceModel = state.quickPickInferenceModel.label.replace(
+    `$(symbol-function)  `,
+    ''
+  )
+  const embeddingModel = state.quickPickEmbeddingModel.label.replace(
+    `$(symbol-function)  `,
+    ''
+  )
+
   await ConfigurationSettingService.loadConfigurationService({
     serviceProvider: 'OpenAI',
     baseUrl: state.openaiBaseUrl,
-    defaultModel: state.quickPickInferenceModel.label,
-    embeddingModel: state.quickPickEmbeddingModel.label,
+    defaultModel: inferenceModel,
+    embeddingModel: embeddingModel,
     azureDeployment: 'setup-required',
     embeddingsDeployment: 'setup-required',
     azureApiVersion: '2023-05-15',

--- a/src/quickPicks/quickPickSetupVscodeOpenai.ts
+++ b/src/quickPicks/quickPickSetupVscodeOpenai.ts
@@ -64,7 +64,7 @@ export async function quickPickSetupVscodeOpenai(
   function getAvailableRuntimes(): QuickPickItem[] {
     const quickPickItemTypes: QuickPickItem[] = [
       {
-        label: 'GitHub',
+        label: '$(github)  GitHub',
         description:
           'Use your github.com profile to sign into to vscode-openai service',
       },


### PR DESCRIPTION
- Modified `src/constants/constants.ts` to change the value of `CHANGE_MODEL` from `$(symbol-function)  Change Models` to `$(extensions)  change models`.
- Modified `src/quickPicks/getAvailableModels.ts` to add a `$(symbol-function)` prefix to the label of each chat completion model.
- Modified `src/quickPicks/quickPickChangeModel.ts` to remove the `$(symbol-function)` prefix from the selected inference and embedding models before setting them as the default models in `ConfigurationSettingService`.
- Modified `src/quickPicks/quickPickSetupAzureOpenai.ts` to add a `$(globe)` prefix to the prompt for entering the OpenAI base URL, a `$(key)` prefix to the prompt for entering the OpenAI API key, and to remove the `$(symbol-function)` prefix from the selected inference and embedding deployments before setting them in the configuration.
- Modified `src/quickPicks/quickPickSetupCredalOpenai.ts` to add a `$(key)` prefix to the prompt for entering the OpenAI API key and a `$(symbol-function)` prefix to the placeholder for the selected chat completion deployment model.
- Modified `src/quickPicks/quickPickSetupOpenai.ts` to add a `$(globe)` prefix to the prompt for entering the OpenAI base URL, a `$(key)` prefix to the prompt for entering the OpenAI API key, and to remove the `$(symbol-function)` prefix from the selected inference and embedding models before setting them in the configuration.
- Modified `src/quickPicks/quickPickSetupVscodeOpenai.ts` to add a `$(github)` prefix to the label for the GitHub runtime.