### PR TITLE
The changes made in this commit include:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "vscode-openai" extension will be documented in this 
 
 <!-- Check [Keep a Changelog](https://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## [1.3.11]
+
+- BugFix/20230721-Enable Enterprise Auth on Azure
+
 ## [1.3.10]
 
 - BugFix/20230721-Adding Custom Header To ListModel

--- a/src/quickPicks/quickPickSetupAzureOpenai.ts
+++ b/src/quickPicks/quickPickSetupAzureOpenai.ts
@@ -168,11 +168,8 @@ export async function quickPickSetupAzureOpenai(
     name: string
   ): Promise<string | undefined> {
     const OPENAI_APIKEY_LENGTH = 32
-    const OPENAI_OAUTH2_STARTSWITH = 'ey'
-
     // Native azure service key or oauth2 token
-    return name.length >= OPENAI_APIKEY_LENGTH ||
-      name.startsWith(OPENAI_OAUTH2_STARTSWITH)
+    return name.length >= OPENAI_APIKEY_LENGTH
       ? undefined
       : 'Invalid Api-Key or Token'
   }


### PR DESCRIPTION
- Added [file name]
- Modified [file name] to [brief description of change]
- Deleted [file name]

In the `quickPickSetupAzureOpenai.ts` file, the code was modified to remove the check for `OPENAI_OAUTH2_STARTSWITH` as it is no longer needed. The function now only checks if the length of the `name` parameter is greater than or equal to `OPENAI_APIKEY_LENGTH` to determine if the API key or token is valid.