### PR TITLE
In package.json:

### DIFF
--- a/package.json
+++ b/package.json
@@ -368,8 +368,8 @@
     "menus": {
       "webview/context": [
         {
-          "command": "vscode-openai.messages.clipboard-message",
-          "when": "webviewId == 'vscode-openai.webview.messages' && webviewSection == 'menu'",
+          "command": "_vscode-openai.messages.clipboard-copy.message",
+          "when": "webviewId == 'vscode-openai.webview.messages' && webviewSection == 'message'",
           "group": "inline@1"
         },
         {
@@ -563,8 +563,8 @@
         "category": "_vscode-openai.conversation.delete"
       },
       {
-        "command": "vscode-openai.messages.clipboard-message",
-        "title": "Copy 🦁",
+        "command": "_vscode-openai.messages.clipboard-copy.message",
+        "title": "Copy Message",
         "category": "vscode-openai.messages.menu"
       },
       {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -35,6 +35,7 @@ import {
   EditorCodeOptimizeCommand,
   EditorCodePatternsCommand,
 } from './editor'
+import { ClipboardCopyMessagesMessageCommand } from './messages'
 
 export { CommandManager }
 export function registerVscodeOpenAICommands(
@@ -55,6 +56,9 @@ export function registerVscodeOpenAICommands(
   commandManager.register(new RefreshConversationsCommand())
   commandManager.register(new DeleteAllConversationsCommand())
   commandManager.register(new SettingsConversationsCommand())
+
+  // Messages
+  commandManager.register(new ClipboardCopyMessagesMessageCommand())
 
   // Embeddings
   commandManager.register(new EmbeddingsRefreshCommand(embeddingTree))

--- a/src/commands/messages/copyClipboardMessage.ts
+++ b/src/commands/messages/copyClipboardMessage.ts
@@ -1,0 +1,14 @@
+import { env } from 'vscode'
+import { Command } from '../commandManager'
+import { showMessageWithTimeout } from '@app/apis/vscode'
+import { IChatCompletion } from '@app/types'
+
+export default class ClipboardCopyMessagesMessageCommand implements Command {
+  public readonly id = '_vscode-openai.messages.clipboard-copy.message'
+
+  public execute(args: { data: IChatCompletion }) {
+    const content = args.data.content
+    env.clipboard.writeText(content)
+    showMessageWithTimeout(`Clipboard-Copy: ${content}`, 5000)
+  }
+}

--- a/src/commands/messages/index.ts
+++ b/src/commands/messages/index.ts
@@ -1,0 +1,1 @@
+export { default as ClipboardCopyMessagesMessageCommand } from './copyClipboardMessage'

--- a/webview-ui/messageWebview/src/components/MessageHistory/MessageHistory.tsx
+++ b/webview-ui/messageWebview/src/components/MessageHistory/MessageHistory.tsx
@@ -51,7 +51,10 @@ const MessageHistory: FC<IMessageHistoryProps> = ({ message }) => {
   return (
     <div
       style={styleMessageHistory}
-      data-vscode-context='{"webviewSection": "menu"}'
+      data-vscode-context={JSON.stringify({
+        webviewSection: 'message',
+        data: message,
+      })}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
         <div style={{ paddingBottom: 10 }}>


### PR DESCRIPTION
- Updated the command for copying messages in the webview context menu.
- Changed the command from "vscode-openai.messages.clipboard-message" to "_vscode-openai.messages.clipboard-copy.message".
- Updated the "when" condition to check for the webviewSection value of "message" instead of "menu".

In index.ts:
- Added a new import statement for the ClipboardCopyMessagesMessageCommand class from the messages.ts file.
- Registered the new command by calling the register method of the commandManager instance.

In MessageHistory.tsx:
- Updated the data-vscode-context attribute to include the webviewSection value of "message" and the message data.