### PR TITLE
fix: synchronization issue in compareFileToClipboard

### DIFF
--- a/src/apis/vscode/editorServices/compareFileToClipboard.ts
+++ b/src/apis/vscode/editorServices/compareFileToClipboard.ts
@@ -1,18 +1,19 @@
 import { commands, env, window } from 'vscode'
 
 export async function compareFileToClipboard(newValue: string) {
-  const clipboard = await env.clipboard.readText()
+  const originalValue = await env.clipboard.readText()
   try {
     const editor = window.activeTextEditor
     if (editor) {
-      env.clipboard.writeText(newValue)
-      commands.executeCommand(
+      await env.clipboard.writeText(newValue)
+      await commands.executeCommand(
         'workbench.files.action.compareWithClipboard',
         editor.document.uri
       )
     }
   } catch (error) {
     window.showErrorMessage(error as string)
+  } finally {
+    await env.clipboard.writeText(originalValue)
   }
-  env.clipboard.writeText(clipboard)
 }


### PR DESCRIPTION
three calls were running parallely:
1. new clipboard value writing
2. `workbench.files.action.compareWithClipboard` execution
3. original clipboard value restoration.

That caused a major bug where `...compareWithClipboard` ran over the original clipboard 
instead of the new one. That could happen due to these routes:
[(2),(1),(3)], [(2),(3),(1)], [(1),(3),(2)], [(3),(2),(1)]
Also, that could potentially break the clipboard if the route would be: [(2),(3),(1)],[(3),(2),(1)],[(3),(1),(2)]
This change is for making sure route is always:
[(1)(2)(3)]