### PR TITLE
Bugfix: Interrupting Completion Causes Side Effects

### DIFF
--- a/src/panels/messageViewerPanel/messageViewerPanel.ts
+++ b/src/panels/messageViewerPanel/messageViewerPanel.ts
@@ -271,8 +271,6 @@ export class MessageViewerPanel {
       MessageViewerPanel.postMessage(type, data);
     }
 
-    // TODO: Prevent the response from writing into the interrupting message which still happens very occasionally
-    // Possibly when stream is completed before being aborted?
     if (this._abortController) {
       this._abortController.abort("User aborted chat completion.");
     }

--- a/src/panels/messageViewerPanel/messageViewerPanel.ts
+++ b/src/panels/messageViewerPanel/messageViewerPanel.ts
@@ -1,32 +1,32 @@
 import {
-  Disposable,
-  Webview,
-  WebviewPanel,
-  window,
-  Uri,
-  ViewColumn,
-  ColorThemeKind,
-  ColorTheme,
-  EventEmitter,
-  Event,
-} from 'vscode';
-import { getUri, getNonce } from '@app/apis/vscode';
-import { IChatCompletion, ICodeDocument, IConversation } from '@app/interfaces';
-import {
   createChatCompletionMessage,
   createChatCompletionStream,
 } from '@app/apis/openai';
+import { getNonce, getUri } from '@app/apis/vscode';
+import { IChatCompletion, ICodeDocument, IConversation } from '@app/interfaces';
+import {
+  ChatCompletionConfig,
+  ChatCompletionModelType,
+  ConversationConfig as convCfg,
+  ConversationColorConfig as convColorCfg,
+} from '@app/services/configuration';
+import {
+  ColorTheme,
+  ColorThemeKind,
+  Disposable,
+  Event,
+  EventEmitter,
+  Uri,
+  ViewColumn,
+  Webview,
+  WebviewPanel,
+  window,
+} from 'vscode';
 import {
   onDidCopyClipboardCode,
   onDidCreateDocument,
   onDidSaveMessages,
 } from './onDidFunctions';
-import {
-  ChatCompletionConfig,
-  ConversationColorConfig as convColorCfg,
-  ConversationConfig as convCfg,
-  ChatCompletionModelType,
-} from '@app/services/configuration';
 
 export class MessageViewerPanel {
   private static _currentPanel: MessageViewerPanel | undefined;
@@ -34,6 +34,7 @@ export class MessageViewerPanel {
   private _conversation: IConversation | undefined;
   private _disposables: Disposable[] = [];
   private readonly _extensionUri: Uri;
+  private _abortController: AbortController | undefined;
 
   private _emitter = new EventEmitter<IConversation>();
   readonly onDidChangeConversation: Event<IConversation> = this._emitter.event;
@@ -103,7 +104,7 @@ export class MessageViewerPanel {
   }
 
   private _render() {
-    if (!this._conversation) {return;}
+    if (!this._conversation) { return; }
 
     // Set the HTML content for the webview panel
     this._panel.webview.html = this._getWebviewContent(
@@ -224,7 +225,7 @@ export class MessageViewerPanel {
           case 'onDidSaveMessages': {
             const chatMessages: IChatCompletion[] = JSON.parse(message.text);
 
-            if (!this._conversation) {return;}
+            if (!this._conversation) { return; }
             onDidSaveMessages(this._conversation, chatMessages);
             // If the last item was from user
             if (chatMessages[chatMessages.length - 1].mine === true) {
@@ -257,7 +258,7 @@ export class MessageViewerPanel {
   }
 
   private async _askQuestion(): Promise<void> {
-    if (!this._conversation) {return;}
+    if (!this._conversation) { return; }
 
     const cfg = ChatCompletionConfig.create(ChatCompletionModelType.INFERENCE);
 
@@ -270,11 +271,19 @@ export class MessageViewerPanel {
       MessageViewerPanel.postMessage(type, data);
     }
 
+    // TODO: Prevent the response from writing into the interrupting message which still happens very occasionally
+    // Possibly when stream is completed before being aborted?
+    if (this._abortController) {
+      this._abortController.abort("User aborted chat completion.");
+    }
+    this._abortController = new AbortController();
+
     const isStreamSuccessful = await createChatCompletionStream(
       this._conversation,
       cfg,
       messageCallback,
-      streamCallback
+      streamCallback,
+      this._abortController.signal
     );
 
     if (!isStreamSuccessful) {

--- a/webview/message/src/components/MessageList/index.tsx
+++ b/webview/message/src/components/MessageList/index.tsx
@@ -1,11 +1,11 @@
-import { Field, ProgressBar, mergeClasses } from '@fluentui/react-components'
-import { FC, useEffect, useRef, useState, useCallback } from 'react'
-import { MessageItem } from '@app/components/MessageItem'
-import { MessageInput } from '@app/components/MessageInput'
-import { vscode } from '@app/utilities'
-import { IChatCompletion } from '@app/interfaces'
-import { useMessageListStyles } from './styles/useMessageListStyles'
-import { WelcomeMessageBar } from './components/WelcomeMessageBar'
+import { MessageInput } from '@app/components/MessageInput';
+import { MessageItem } from '@app/components/MessageItem';
+import { IChatCompletion } from '@app/interfaces';
+import { vscode } from '@app/utilities';
+import { Field, ProgressBar, mergeClasses } from '@fluentui/react-components';
+import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { WelcomeMessageBar } from './components/WelcomeMessageBar';
+import { useMessageListStyles } from './styles/useMessageListStyles';
 
 export const MessageList: FC = () => {
   const bottomAnchorRef = useRef<HTMLDivElement>(null)
@@ -55,6 +55,12 @@ export const MessageList: FC = () => {
         setChatCompletionList((prevList) => {
           const updatedList = [...prevList]
           const lastItemIndex = updatedList.length - 1
+
+          // User never streams, must have been something wrong
+          if (updatedList[lastItemIndex].mine) { 
+            console.warn('Attempted to write to the user input.');
+            return prevList;
+          }
 
           // Check if there are existing messages to append the stream to
           if (lastItemIndex >= 0) {


### PR DESCRIPTION
When interrupting a completion request, abort the request and prevent unintended behavior (additional calls, writing to user's message)

#340 

![image](https://github.com/user-attachments/assets/c1adc346-9671-4be8-a3a0-0509bfe6872c)
![image](https://github.com/user-attachments/assets/9e47fed9-aa66-492b-a887-5d513ccc4218)
